### PR TITLE
Improve clarity of exponent in section "absolute error" of floating_error.html

### DIFF
--- a/floating_error.html
+++ b/floating_error.html
@@ -121,13 +121,13 @@ know how to represent it in floating point?</p>
 <p>A simple algorithm might be to get the exponent by an algorithm like this:</p>
 <div class="highlight-python notranslate"><div class="highlight"><pre><span></span><span class="n">x1</span> <span class="o">=</span> <span class="nb">abs</span><span class="p">(</span><span class="n">x</span><span class="p">)</span>
 <span class="n">e1</span> <span class="o">=</span> <span class="n">logB</span><span class="p">(</span><span class="n">x1</span><span class="p">)</span>
-<span class="n">exponent</span> <span class="o">=</span> <span class="n">floor</span><span class="p">(</span><span class="n">e1</span><span class="p">)</span>
+<span class="n">e2</span> <span class="o">=</span> <span class="n">floor</span><span class="p">(</span><span class="n">e1</span><span class="p">)</span>
 </pre></div>
 </div>
 <p>Where <span class="math notranslate nohighlight">\(abs(y)\)</span> gives the absolute value of <span class="math notranslate nohighlight">\(y\)</span>, <span class="math notranslate nohighlight">\(logB(y)\)</span> is the log to base
 <span class="math notranslate nohighlight">\(\beta\)</span>, and <span class="math notranslate nohighlight">\(floor(y)\)</span> gives the most positive integer <span class="math notranslate nohighlight">\(i\)</span>, such that <span class="math notranslate nohighlight">\(i &lt;=
 y\)</span> <a class="footnote-reference brackets" href="#floor" id="id1" role="doc-noteref"><span class="fn-bracket">[</span>1<span class="fn-bracket">]</span></a>.</p>
-<p>We can then get the mantissa part with <span class="math notranslate nohighlight">\(round(x / \beta^{e2}, p-1)\)</span>, where
+<p>We can then get the mantissa part with <span class="math notranslate nohighlight">\(round(x / \beta^{e_2}, p-1)\)</span>, where
 <span class="math notranslate nohighlight">\(round(y, z)\)</span> rounds the number <span class="math notranslate nohighlight">\(y\)</span> to <span class="math notranslate nohighlight">\(z\)</span> digits after the decimal point.</p>
 <p>Worked example in Python with our original system of <span class="math notranslate nohighlight">\(p = 3, \beta = 10\)</span>:</p>
 <div class="highlight-python notranslate"><div class="highlight"><pre><span></span><span class="kn">from</span> <span class="nn">math</span> <span class="kn">import</span> <span class="nb">abs</span><span class="p">,</span> <span class="n">log10</span><span class="p">,</span> <span class="n">floor</span><span class="p">,</span> <span class="nb">round</span>
@@ -135,7 +135,7 @@ y\)</span> <a class="footnote-reference brackets" href="#floor" id="id1" role="d
 <span class="n">p</span> <span class="o">=</span> <span class="mi">3</span> <span class="c1"># number of digits in mantissa</span>
 <span class="n">x1</span> <span class="o">=</span> <span class="nb">abs</span><span class="p">(</span><span class="n">x</span><span class="p">)</span> <span class="c1"># 0.1234</span>
 <span class="n">e1</span> <span class="o">=</span> <span class="n">log10</span><span class="p">(</span><span class="n">x1</span><span class="p">)</span> <span class="c1"># -0.9086848403027772</span>
-<span class="n">exponent</span> <span class="o">=</span> <span class="n">floor</span><span class="p">(</span><span class="n">e1</span><span class="p">)</span> <span class="c1"># -1</span>
+<span class="n">e2</span> <span class="o">=</span> <span class="n">floor</span><span class="p">(</span><span class="n">e1</span><span class="p">)</span> <span class="c1"># -1</span>
 <span class="n">m1</span> <span class="o">=</span> <span class="n">x</span> <span class="o">/</span> <span class="p">(</span><span class="mi">10</span> <span class="o">**</span> <span class="n">e2</span><span class="p">)</span> <span class="c1"># -1.234</span>
 <span class="n">mantissa</span> <span class="o">=</span> <span class="nb">round</span><span class="p">(</span><span class="n">m1</span><span class="p">,</span> <span class="n">p</span><span class="o">-</span><span class="mi">1</span><span class="p">)</span> <span class="c1"># -1.23</span>
 </pre></div>


### PR DESCRIPTION
Problem:
There are references to some e2, which is never defined. e2 is also used in the mathblock making it ambiguous with $e \cdot 2$.

Fix:
- Changed "exponent" to "e2" in code-blocks, another option could be to be consistent with the use of "exponent" but this is a cumbersome variable name to use in the math-block so I opted for e2.
- Changed "e2" to "e_2" in the math-block, so ambiguity is resolved.

